### PR TITLE
feat: enforce node version on install

### DIFF
--- a/hedgehog-lab/package.json
+++ b/hedgehog-lab/package.json
@@ -59,6 +59,9 @@
       "last 1 safari version"
     ]
   },
+  "engines": {
+    "node": ">=10.0.0"
+  },
   "devDependencies": {
     "gh-pages": "^3.0.0",
     "typescript": "^3.9.3"


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/41336612/87847299-aba7a200-c909-11ea-8648-aefd2085378a.png)
yarn安装依赖时，强制node版本为10.0.0及以上。