### PR TITLE
feat(tex): support tag function calls in TeX

### DIFF
--- a/packages/hedgehog-core/src/runtime/prelude.ts
+++ b/packages/hedgehog-core/src/runtime/prelude.ts
@@ -7,6 +7,7 @@ import _MathLib from '../lib/mathlib';
 import { Sym } from '../lib/symbolic';
 import { Chol, QR, LU } from '../lib/algebra';
 import { OutputItem } from '../output/output-item';
+import processRawInputs from '../utilites/process-raw-inputs';
 
 export { Sym, Mat, Scalar, _Mat };
 
@@ -306,11 +307,13 @@ export function plot3DMesh(x_: any, y_: any, z_: any) {
 }
 
 // show Tex in MathJax
-export function tex(inputTex: string) {
+export function tex(...inputs: any[]) {
+  const inputTex: string = processRawInputs(...inputs);
   _OUTPUT_ITEMS_LIST_.push({ itemType: 'TEX', text: inputTex });
 }
 
-export function formulaTex(inputTex: string) {
+export function formulaTex(...inputs: any[]) {
+  const inputTex: string = processRawInputs(...inputs);
   _OUTPUT_ITEMS_LIST_.push({ itemType: 'FORMULA', text: inputTex });
 }
 

--- a/packages/hedgehog-core/src/utilites/process-raw-inputs.ts
+++ b/packages/hedgehog-core/src/utilites/process-raw-inputs.ts
@@ -1,0 +1,24 @@
+/**
+ * Processes the raw string inputs using `String.raw()`.
+ *
+ * @example
+ * // called as a normal function
+ * processRawInputs('Results:\\n' + res);
+ *
+ * @example
+ * // called as a tag function
+ * processRawInputs`Results:\n${res}`
+ *
+ * @param tmpl template call site object or anything
+ * @param vals substituion values
+ *
+ * @returns the generated string when the first argument is a
+ *    template call site object(i.e. contains a `.raw` property),
+ *    otherwise returns the first argument as is.
+ */
+export default function processRawInputs(
+  tmpl?: TemplateStringsArray | any,
+  ...vals: any[]
+): string | any {
+  return tmpl?.raw ? String.raw(tmpl, ...vals) : tmpl;
+}

--- a/packages/hedgehog-lab/src/tutorials.ts
+++ b/packages/hedgehog-lab/src/tutorials.ts
@@ -115,6 +115,14 @@ let L = chol(A).L;
 // and keep 5 digits 
 L.digits = 5
 tex("\\\\text{where A is a positive-definite and symmetric matrix.} \\\\\\\\ \\\\text{For example, we have } A = " + A.toTex() + "\\\\text{, and the decomposed matrix L is }" + L.toTex())
+
+// You can use tag functions to simplify the code
+tex\`\\textit{Here comes HE}\`
+formulaTex\`
+  \\Theta
+    \\text{\${'\\u002e'.repeat(2)}}
+  \\Theta
+\`
 `;
 
 const graphicsSource = `// generate 2D points as vectors of x and y 


### PR DESCRIPTION
This pull request contains the following changes:

1. Added a helper function `processRawInputs()` in `packages/hedgehog-core/src/utilites/` to process raw string inputs; (BTW, I think the directory name `utilites` should be `utilities` 🤣.)
2. Refactored `tex()` and `formulaTex()` to support tag function calls;
3. Added demos using tag functions in the TeX tutorial.

As mentioned in #62.

![image](https://user-images.githubusercontent.com/6022672/88459857-36246e80-ced3-11ea-8e54-59220e938305.png)
