### PR TITLE
feat(tex): automatically converts raw inputs into TeX if possible

### DIFF
--- a/packages/hedgehog-core/src/runtime/prelude.ts
+++ b/packages/hedgehog-core/src/runtime/prelude.ts
@@ -7,7 +7,7 @@ import _MathLib from '../lib/mathlib';
 import { Sym } from '../lib/symbolic';
 import { Chol, QR, LU } from '../lib/algebra';
 import { OutputItem } from '../output/output-item';
-import processRawInputs from '../utilites/process-raw-inputs';
+import { rawInputsToTex } from '../utilites/process-raw-inputs';
 
 export { Sym, Mat, Scalar, _Mat };
 
@@ -308,12 +308,12 @@ export function plot3DMesh(x_: any, y_: any, z_: any) {
 
 // show Tex in MathJax
 export function tex(...inputs: any[]) {
-  const inputTex: string = processRawInputs(...inputs);
+  const inputTex: string = rawInputsToTex(...inputs);
   _OUTPUT_ITEMS_LIST_.push({ itemType: 'TEX', text: inputTex });
 }
 
 export function formulaTex(...inputs: any[]) {
-  const inputTex: string = processRawInputs(...inputs);
+  const inputTex: string = rawInputsToTex(...inputs);
   _OUTPUT_ITEMS_LIST_.push({ itemType: 'FORMULA', text: inputTex });
 }
 

--- a/packages/hedgehog-core/src/utilites/process-raw-inputs.ts
+++ b/packages/hedgehog-core/src/utilites/process-raw-inputs.ts
@@ -35,14 +35,21 @@ export default function processRawInputs(
  * @param tmpl template call site object or anything
  * @param vals substituion values
  *
- * @returns the generated string when the first argument is a
- *    template call site object(i.e. contains a `.raw` property),
- *    otherwise returns the first argument as is.
+ * @returns
+ *    1. the TeX string of the first argument if it contains `.toTex()` method;
+ *    2. the generated string if the first argument is a
+ *       template call site object(i.e. contains a `.raw` property);
+ *    3. otherwise returns the first argument as is.
  */
 export function rawInputsToTex(
   tmpl?: TemplateStringsArray | any,
   ...vals: any[]
 ): string | any {
+  // returns the TeX string of `tmpl` if it contains `.toTex()` method
+  if (tmpl?.toTex) {
+    return tmpl.toTex();
+  }
+
   // automatically converts substituion values into TeX if possible
   vals = vals.map(v => v?.toTex?.() ?? v);
 

--- a/packages/hedgehog-core/src/utilites/process-raw-inputs.ts
+++ b/packages/hedgehog-core/src/utilites/process-raw-inputs.ts
@@ -22,3 +22,29 @@ export default function processRawInputs(
 ): string | any {
   return tmpl?.raw ? String.raw(tmpl, ...vals) : tmpl;
 }
+
+/**
+ * This function behaves the same as @function processRawInputs(),
+ * except that substituion values will be automatically converted
+ * into TeX if possible.
+ *
+ * @example
+ * let a = mat([[1,1,4], [5,1,4]]);
+ * rawInputsToTex`A = ${a}`; //=> "A = \begin{bmatrix}...\end{bmatrix}"
+ *
+ * @param tmpl template call site object or anything
+ * @param vals substituion values
+ *
+ * @returns the generated string when the first argument is a
+ *    template call site object(i.e. contains a `.raw` property),
+ *    otherwise returns the first argument as is.
+ */
+export function rawInputsToTex(
+  tmpl?: TemplateStringsArray | any,
+  ...vals: any[]
+): string | any {
+  // automatically converts substituion values into TeX if possible
+  vals = vals.map(v => v?.toTex?.() ?? v);
+
+  return processRawInputs(tmpl, ...vals);
+}

--- a/packages/hedgehog-core/src/utilites/process-raw-inputs.ts
+++ b/packages/hedgehog-core/src/utilites/process-raw-inputs.ts
@@ -16,7 +16,7 @@
  *    template call site object(i.e. contains a `.raw` property),
  *    otherwise returns the first argument as is.
  */
-export default function processRawInputs(
+export function processRawInputs(
   tmpl?: TemplateStringsArray | any,
   ...vals: any[]
 ): string | any {

--- a/packages/hedgehog-core/src/utilites/process-raw-inputs.ts
+++ b/packages/hedgehog-core/src/utilites/process-raw-inputs.ts
@@ -32,13 +32,16 @@ export default function processRawInputs(
  * let a = mat([[1,1,4], [5,1,4]]);
  * rawInputsToTex`A = ${a}`; //=> "A = \begin{bmatrix}...\end{bmatrix}"
  *
+ * @example
+ * rawInputsToTex(a); //=> "\begin{bmatrix}...\end{bmatrix}"
+ *
  * @param tmpl template call site object or anything
  * @param vals substituion values
  *
  * @returns
  *    1. the TeX string of the first argument if it contains `.toTex()` method;
- *    2. the generated string if the first argument is a
- *       template call site object(i.e. contains a `.raw` property);
+ *    2. the generated string if the first argument is a template call site object
+ *       (i.e. contains a `.raw` property);
  *    3. otherwise returns the first argument as is.
  */
 export function rawInputsToTex(

--- a/packages/hedgehog-lab/src/tutorials.ts
+++ b/packages/hedgehog-lab/src/tutorials.ts
@@ -123,6 +123,11 @@ formulaTex\`
     \\text{\${'\\u002e'.repeat(2)}}
   \\Theta
 \`
+
+// and the \`toTex()\` method will be automatically called
+formulaTex\`
+  \${mat([[1,1,4],[5,1,4]])}
+\`
 `;
 
 const graphicsSource = `// generate 2D points as vectors of x and y 

--- a/packages/hedgehog-lab/src/tutorials.ts
+++ b/packages/hedgehog-lab/src/tutorials.ts
@@ -16,14 +16,14 @@ print("Creating a matrix from csv: \\n" + b);
 //4. Also there are some useful built-in functions to create different kinds of matrix
 print("Creating a 3-by-3 eye matrix:\\n" + eye(3));
 print("Creating a random 2-by-3 matrix:\\n" + random(2,3));
-print("Creating a matrix of ones:\\n" + ones(2)); 
-print("Creating a matrix of zeros:\\n" + zeros(2)); 
+print("Creating a matrix of ones:\\n" + ones(2));
+print("Creating a matrix of zeros:\\n" + zeros(2));
 
 //5. You can also create a sequence of number starting with 1 ending with 20 and increasing with step 3, then reshape it as a 3-by-3 matrix
 print("Matrix c is:\\n" + range(1,20,3).reshape(3,3));
 `;
 
-const operatorsSource = `// Operator overloads are available for Mat class. 
+const operatorsSource = `// Operator overloads are available for Mat class.
 // Right operator could be Mat object, 2D or 1D array or number
 
 let A = mat([[1,2],[3,4]]);
@@ -46,7 +46,7 @@ print("A/2=\\n" + (A/2));
 // For element-wise multiplication (the same as A.*B in Matlab), use operator '**' instead
 print("A**A=\\n" + (A**A))
 
-// and if the right operand of operator "**" is a number N, it will generate an element-wise 
+// and if the right operand of operator "**" is a number N, it will generate an element-wise
 // power of N to the left operand matrix (the same as A.^N in Matlab)
 print("A**2=\\n" + A**2);
 
@@ -83,8 +83,8 @@ toc();
 `;
 
 const buildInFunctionsSource = `/*
-There are many built-in functions which support matrix, including     
-sin, cos, abs, acos, acosh, sign, 
+There are many built-in functions which support matrix, including
+sin, cos, abs, acos, acosh, sign,
 sqrt, trunc, floor, ceil, exp, log,
 asin, asinh, atan, atanh, tan, tanh,
 pow, round
@@ -97,7 +97,7 @@ A.digits = 5;
 
 print(sin(A));
 print(log(A));  // log A with base e
-print(log(A,2));  // log A with base 2 
+print(log(A,2));  // log A with base 2
 
 //More functions are on the way...
 `;
@@ -112,7 +112,7 @@ formulaTex("A=LL^{T},")
 // let's  calculate the cholesky now
 let L = chol(A).L;
 
-// and keep 5 digits 
+// and keep 5 digits
 L.digits = 5
 tex("\\\\text{where A is a positive-definite and symmetric matrix.} \\\\\\\\ \\\\text{For example, we have } A = " + A.toTex() + "\\\\text{, and the decomposed matrix L is }" + L.toTex())
 
@@ -130,15 +130,15 @@ formulaTex\`
 \`
 `;
 
-const graphicsSource = `// generate 2D points as vectors of x and y 
+const graphicsSource = `// generate 2D points as vectors of x and y
 let x = range(-10,10,0.1);
 let y = sin(x) + random(1,x.cols);
 
-// plot x and y as scatter 
-plot2D(x.toArray(),y.toArray());  
+// plot x and y as scatter
+plot2D(x.toArray(),y.toArray());
 
 // ploy x and y as line
-plot2DLine(x.toArray(),y.toArray());   
+plot2DLine(x.toArray(),y.toArray());
 
 // generate 3D points as vectors of x, y and z
 let size = 30;
@@ -150,15 +150,15 @@ let z = x**2 + y**2;
 // plot x,y,z as scatter in 3D
 plot3D(x.toArray(),y.toArray(), z.toArray());
 
-// mesh of x,y,z 
+// mesh of x,y,z
 plot3DMesh(x.toArray(),y.toArray(),z.toArray());
 
-/* For more advanced features and different kinds of charts, 
+/* For more advanced features and different kinds of charts,
    please check the official website plotly.js https://plotly.com/javascript/
    and use built-in function draw(data, layout) instead.
 */
 
-/* For more advanced features and different kinds of charts, 
+/* For more advanced features and different kinds of charts,
    please check the official website plotly.js https://plotly.com/javascript/
    and use built-in function draw(data, layout) instead.
 */
@@ -172,7 +172,7 @@ draw([{x:x.toArray(), y: y.toArray(), z: z.toArray(), mode: 'markers',marker: {c
 
 // Example 2 of draw()
 
-// dataset group 1 
+// dataset group 1
 let x1 = random(1,20)*2 + 2;
 let y1 = random(1,20)*3 + 3;
 
@@ -184,8 +184,8 @@ let y2 = random(1,20)* 0.8 - 1;
 let x3 = random(1,30) * 1 - 1;
 let y3 = random(1,30) * 3 + 2;
 
-draw( 
-[{x:x1.toArray(), y:y1.toArray(), mode:"markers"}, {x:x2.toArray(), y:y2.toArray(), mode:"markers"}, {x:x3.toArray(), y:y3.toArray(), mode:"markers"}], 
+draw(
+[{x:x1.toArray(), y:y1.toArray(), mode:"markers"}, {x:x2.toArray(), y:y2.toArray(), mode:"markers"}, {x:x3.toArray(), y:y3.toArray(), mode:"markers"}],
 {shapes: [{type:'circle', xref:'x', yref:'y', x0 : x1.min(), y0:y1.min(), x1: x1.max(), y1: y1.max(), opacity: 0.2, fillcolor: "green"}, {type:'circle', xref:'x', yref:'y', x0 : x2.min(), y0:y2.min(), x1: x2.max(), y1: y2.max(), opacity: 0.2, fillcolor: "blue"}, {type:'circle', xref:'x', yref:'y', x0 : x3.min(), y0:y3.min(), x1: x3.max(), y1: y3.max(), opacity: 0.2, fillcolor: "red"}], title:"Example 2 of draw(): cluster"}
 );
 `;
@@ -195,27 +195,27 @@ let x = sym('x')
 //write expression
 let fx = ( x^2 ) + exp(x) + sin(x)
 
-//print f(x) 
-formulaTex(\`f(x) = \` + fx.toTex())
+//print f(x)
+formulaTex\`f(x) = \${fx}\`
 
 //print f'(x)
-formulaTex(\`f'(x) = \` + diff(fx,x).toTex())
+formulaTex\`f'(x) = \${diff(fx,x)}\`
 
 //print integrate of f(x)
-formulaTex(\`\\\\int{f(x)dx} = \` + integrate(fx,x).toTex())
+formulaTex\`\\int{f(x)dx} = \${integrate(fx,x)}\`
 
 
 //define g(x)
 let gx = fx*fx + 1/fx + cos(x)
 
 //print g(x)
-formulaTex(\`g(x) = \` + gx.toTex())
+formulaTex\`g(x) = \${gx}\`
 
 //print g'(x)
-formulaTex(\`g'(x) = \` + diff(gx,x).toTex())
+formulaTex\`g'(x) = \${diff(gx,x)}\`
 
 //print integrate of g(x)
-formulaTex(\`\\\\int{g(x)dx} = \` + integrate(gx,x).toTex())
+formulaTex\`\\int{g(x)dx} = \${integrate(gx,x)}\`
 
 //define another two symbols
 let w = sym('w');
@@ -225,25 +225,25 @@ let y = sym('y');
 let W = (x^w) + sin(w+y) + (y^-2) + 1/w + log(cos(x) + sin(x))
 
 // W
-formulaTex(\`W(x,y,w) = \` + W.toTex())
+formulaTex\`W(x,y,w) = \${W}\`
 
 // dW / dx
-formulaTex(\`\\\\frac{dW(x,y,w)}{dx} = \` + diff(W,x).toTex());
+formulaTex\`\\frac{dW(x,y,w)}{dx} = \${diff(W,x)}\`
 
 // dW / dy
-formulaTex(\`\\\\frac{dW(x,y,w)}{dy} = \` + diff(W,y).toTex());
+formulaTex\`\\frac{dW(x,y,w)}{dy} = \${diff(W,y)}\`
 
 // dW / dw
-formulaTex(\`\\\\frac{dW(x,y,w)}{dw} = \` + diff(W,w).toTex());
+formulaTex\`\\frac{dW(x,y,w)}{dw} = \${diff(W,w)}\`
 
 // integral W on x
-formulaTex(\`\\\\int{W(x,y,w)dx} = \` + integrate(W,x).toTex());
+formulaTex\`\\int{W(x,y,w)dx} = \${integrate(W,x)}\`
 `;
 
 const markdownSource = `markdown(\`
 # Hedgehog Lab Markdown Example
 
-## Plain Text 
+## Plain Text
 
 This is an example for **plain text** in [Hedgehog Lab](https://github.com/lidangzzz/hedgehog-lab)
 
@@ -266,13 +266,13 @@ print(matrixB);
 ## Feel free to arrange any TeX, plotting and Markdown blocks in Hedgehog Lab!
 \`)
 
-formulaTex(\`A = \` + range(1,26).reshape(5,5).toTex())
+formulaTex\`A = \${range(1,26).reshape(5,5)}\`
 
 let x = sym('x')
 let fx = sin(x) + cos(x) + 1/x;
 
-tex(\`\\\\text{Let's define a function in hedgehog lab as: }f(x) = \` + fx.toTex() + \` \\\\text{, and the derivative of the function is:}\`);
-formulaTex(\`f'(x) = \` + diff(fx,x).toTex());
+tex\`\\text{Let's define a function in hedgehog lab as: }f(x) = \${fx} \\text{, and the derivative of the function is:}\`
+formulaTex\`f'(x) = \${diff(fx,x)}\`
 
 let X = range(1,10,0.01);
 let Y = sin(X);


### PR DESCRIPTION
This PR enables users to insert TeX strings without call `.toTex()` method when using tag functions. 

For example, instead of writing codes like:

```js
// before
tex`result: ${res.toTex()}`
```

users can now insert `res` object directly:

```js
// after
tex`result: ${res}`
```

![screenshot](https://user-images.githubusercontent.com/6022672/88466571-bb764600-cf08-11ea-8bd4-7a4046ebe00a.png)
